### PR TITLE
jitpackでJDK11を指定

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
対応内容：
- jitpackでJDK8が指定されていたのでJDK11を指定するよう修正