### PR TITLE
chore: pin GitHub Actions to specific commit hashes

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -6,13 +6,13 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: actions/cache@v2
+      - uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: |
             ~/.gradle/caches
@@ -24,7 +24,7 @@ jobs:
         run: |
           ./gradlew androidDependencies --no-daemon
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
         with:
           ruby-version: 3.1
           bundler-cache: true
@@ -36,13 +36,13 @@ jobs:
   unit_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: actions/cache@v2
+      - uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,13 +9,13 @@ jobs:
   unit_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: actions/cache@v2
+      - uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created to improve the security and stability of our GitHub Actions workflow by pinning action versions to specific commit hashes. This follows the security best practice recommended by GitHub to prevent potential supply chain attacks.

### Detail

This Pull Request changes the version references in our GitHub Actions workflow from floating version tags to specific commit hashes:

- Updates `actions/checkout` from `v4` to `v4.2.2` (commit hash: `11bd71901bbe5b1630ceea73d27597364c9af683`)
- Updates `actions/setup-java` from `v3` to `v3.13.0` (commit hash: `0ab4596768b603586c0de567f2430c30f5b0d2b0`)
- Updates `actions/cache` from `v2` to commit hash `8492260343ad570701412c2f464a5877dc76bace` of the same version
- Updates `ruby/setup-ruby` from `v1` to `v1.227.0` (commit hash: `1a615958ad9d422dd932dc1d5823942ee002799f`)

Benefits of this change:
- Improves reproducibility of workflow runs
- Prevents unexpected action updates
- Provides clear identification of action versions in use

### Checklist

* [x] This PR contains changes related to a single purpose (pinning action versions)
* [x] Commit message includes detailed description of changes and rationale
* [x] No tests needed as this is a workflow configuration change
* [x] No CHANGELOG update needed as this is an internal workflow change